### PR TITLE
Improve keynote image appearance for higher screen resolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 _site
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 A static site, [http://csvconf.com/](http://csvconf.com).
 
 Forked from [martini](https://github.com/codegangsta/martini) gh-pages branch.
+
+## Develop
+
+This is a [Jekyll](https://github.com/jekyll/jekyll) site!
+
+Requirements:
+
+To work on the CSVConf site locally, you'll first need to have the following installed:
+
+- [Ruby](https://www.ruby-lang.org/en/)
+- [Bundler](http://bundler.io/)
+
+Once that's taken care of, here are the steps necessary to get it running locally:
+
+1. clone this repository and `cd` into the `csvconf.com` directory
+1. run the `bundle` command
+1. run `bundle exec jekyll serve -w`
+
+If everything worked, you should now have a local server running at http://localhost:4000. The `w` flag means the server will watch for changes and rebuild, so you can edit the site as needed and see the updated version in your browser right away.
+
+## License
+
+[MIT](LICENSE)

--- a/css/style.css
+++ b/css/style.css
@@ -120,6 +120,12 @@ table.speaker-list {
 .keynote .image:hover {
   opacity: .6;
 }
+@media (min-width: 1024px) {
+  .keynote .image { height: 300px }
+}
+@media (min-width: 1600px) {
+  .keynote .image { height: 400px }
+}
 .keynote h3 {
   display: block;
   text-align: center;


### PR DESCRIPTION
Noticed images were getting cropped a bit too much on high resolution screens. Added a couple of steps (media queries at 1024 & 1600) to improve appearance.

Also added some documentation on running the site locally and added `Gemfile.lock` to `.gitignore`.

## screenshots

### before

![screen shot 2017-02-09 at 12 34 12 pm](https://cloud.githubusercontent.com/assets/427322/22803374/8785dd1a-eec9-11e6-91a2-3521542fc425.png)

### after

![screen shot 2017-02-09 at 1 10 49 pm](https://cloud.githubusercontent.com/assets/427322/22803375/8787b73e-eec9-11e6-9470-9b8a0ba57685.png)
