### PR TITLE
fix keynote profile image image for wide screens

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -211,9 +211,6 @@ table.speaker-list {
 @media (min-width: 1024px) {
   .keynote .image { height: 200px; width: 200px; }
 }
-@media (min-width: 1600px) {
-  .keynote .image { height: 400px }
-}
 .keynote h3 {
   display: block;
   text-align: center;


### PR DESCRIPTION
## before

<img width="1902" alt="screen shot 2017-04-10 at 3 57 50 pm" src="https://cloud.githubusercontent.com/assets/427322/24886001/9b8d899a-1e06-11e7-9824-8f0bb1bda3b5.png">

## after

<img width="1904" alt="screen shot 2017-04-10 at 3 58 13 pm" src="https://cloud.githubusercontent.com/assets/427322/24886004/a1262592-1e06-11e7-9c38-a9130344f41e.png">
