### PR TITLE
Fix faux-bold on headlines

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -70,6 +70,9 @@ table {
   border-collapse: collapse;
   border-style: hidden;
 }
+strong {
+  font-weight: 500;
+}
 
 .link, .link a {
   background-color: white;
@@ -378,24 +381,24 @@ footer {
       color: black;
     }
   }
-  
+
   .button--info {
     width: 100%;
     vertical-align: top;
     display: inline-block;
   }
-  
+
   @media (min-width: 1024px) {
     .button--info {
       width: 30%;
     }
   }
-  
+
   table.locations,
   table.keynotes,
   table.speaker-list {
   }
-  
+
   .keynotes td {
     border-right: none;
   }
@@ -403,17 +406,18 @@ footer {
   .keynote-selector:checked + .keynote {
     background: #f6e4ed;
   }
-  
+
   .keynote .image {
     background-color: #eabed3;
   }
-  
+
   p, a {
     color: black;
   }
 
   h1, h2, h3 {
     color: black;
+    font-weight: 500;
   }
 
   table td, table th {


### PR DESCRIPTION
Currently, only the Medium weight of Fira Sans is being loaded from Google Fonts, but the font-weight property of the main headline and sub-headings are set to weights that correspond to heavier styles. In most browsers this is fine, but in Safari on mobile and desktop, it results in a subtle faux-bold effect.

This change updates the font-weight for h1, h2, h3 and strong in style.scss.