### PR TITLE
Fix link to Code of Conduct

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
   </ul>
 
   <p>
-  We strive to be a supportive and welcoming environment to all attendees. We encourage you to read the <a href="https://confcodeofconduct.com/" title="Conf Code of Conduct Website">Conf Code of Conduct</a> and will be enforcing it.</p>
+  We strive to be a supportive and welcoming environment to all attendees. We encourage you to read the <a href="/coc/" title="Conf Code of Conduct Website">Conf Code of Conduct</a> and will be enforcing it.</p>
   <p>You can revisit
       <a href="/2020/" title="csv,conf,v5 site">csv,conf,v5</a>, <a href="/2019/" title="csv,conf,v4 site">csv,conf,v4</a>, <a href="/2017/" title="csv,conf,v3 site">csv,conf,v3</a> , <a href="/2016/" title="csv,conf,v2 site">csv,conf,v2</a> and <a href="/2014/" title="csv,conf,v1 site">csv,conf,v1</a> conference websites, or watch csv,conf talks on <a href="https://www.youtube.com/channel/UCWq7JfT4PJrCZLmxSOVJOww" title="csv,conf YouTube Channel">YouTube</a>.
   </p>


### PR DESCRIPTION
old link was to untemplated CoC; new link matches the one in the nav bar at the top.