### PR TITLE
Update Readme.md with install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements:
 
 To work on the CSVConf site locally, you'll first need to have the following installed:
 
-- [Ruby](https://www.ruby-lang.org/en/)
+- [Ruby 2.7](https://www.ruby-lang.org/en/)
 - [Bundler](http://bundler.io/)
 
 Once that's taken care of, here are the steps necessary to get it running locally:
@@ -22,6 +22,37 @@ Once that's taken care of, here are the steps necessary to get it running locall
 1. run `bundle exec jekyll serve -w`
 
 If everything worked, you should now have a local server running at http://localhost:4000. The `w` flag means the server will watch for changes and rebuild, so you can edit the site as needed and see the updated version in your browser right away.
+
+## Instalation notes
+
+The current site is only compatible with Ruby 2.7.1.
+
+Using `apt` on Ubuntu 22.04 will install Ruby 3.0, to install a previous version you can use the following instructions:
+
+```bash
+# Install rbenv in your home directory
+$ git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+
+# Add it to your PATH variable
+$ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+$ echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+$ exec $SHELL
+
+# Install ruby-build plugin
+$ git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+
+# Install Ruby 2.7
+$ rbenv install 2.7.1
+$ rbenv global 2.7.1
+
+# Check the correct install
+$ ruby -v
+
+# Install bundler
+$ gem install bundler
+$ rbenv rehash
+
+```
 
 ## License
 


### PR DESCRIPTION
Hello!

Seems the current site is only compatible with Ruby 2.7.1. (I had issues running it since Ubuntu 22.04 installs Ruby 3.0 by default)

I've added some notes to the Readme and some small tutorial to install a previous version of Ruby if the OS installs 3.0.