### PR TITLE
Fix spelling error in front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ title: CSVConf
      <p class="sixty"> Featuring stories about data sharing and data analysis from science, journalism, government, and open source. </p>
 
      <div class ="button--std">
-      <h1> Registeration is open!</h1>
+      <h1> Registration is open!</h1>
       <p><a href ="https://www.eventbrite.com/e/csvconfv8-tickets-808081201627?aff=oddtdtcreator"> Sign up to attend csv,conf,v8</a></p>
     </div>
     <br>


### PR DESCRIPTION
"Regist***e***ration" instead of "registration".