### PR TITLE
Create links from URLs in the schedule abstracts

### DIFF
--- a/assets/js/schedule.js
+++ b/assets/js/schedule.js
@@ -269,7 +269,20 @@ class ScheduleManager {
 			});
 		});
 	}
+
+	linkify(text) {
+	  const urlRegex = /(https?:\/\/[^\s]+)/g;
 	
+	  return text.replace(urlRegex, (url) => {
+		try {
+		  new URL(url);		// Validate URL just in case
+		  return `<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
+		} catch {
+		  return url;
+		}
+	  });
+	}
+
 	showModal(cell) {
 		const title = cell.dataset.title;
 		const speaker = cell.dataset.speaker;
@@ -290,7 +303,7 @@ class ScheduleManager {
 		const abstract = speakerInfo && speakerInfo['Abstract'] ? 
 			speakerInfo['Abstract'] : 
 			`Talk: ${title}`;
-		document.getElementById('modalAbstract').innerHTML = `<strong>Abstract:</strong> ${abstract}`;
+		document.getElementById('modalAbstract').innerHTML = `<strong>Abstract:</strong> ${this.linkify(abstract)}`;
 		
 		// Build bio section with all available info
 		let bioHTML = '';


### PR DESCRIPTION
Adds `<a>` tags around URLs present in the schedule abstracts to save visitors a copy/paste.

Before:

<img width="1472" height="1518" alt="Screenshot 2025-08-19 at 15-29-23 csv conf v9 - Schedule" src="https://github.com/user-attachments/assets/b200c22e-21cf-4fb2-8f0e-8d088feb8855" />



After:
<img width="1566" height="1614" alt="Screenshot from 2025-08-19 15-25-18" src="https://github.com/user-attachments/assets/fd765863-ab6d-47f5-b065-7956ddb994e9" />
